### PR TITLE
4/5 navey floor AKASAKA: 出演者セクションをReG風の縦並びリスト形式に変更

### DIFF
--- a/delicious_spy/band_live_complete_single_bright.html
+++ b/delicious_spy/band_live_complete_single_bright.html
@@ -151,14 +151,14 @@
                         </div>
 
                         <!-- 出演者情報 -->
-                        <div style="background: rgba(155, 89, 182, 0.08); padding: 12px; border-radius: 8px; margin: 10px 0; border: 1px solid rgba(155, 89, 182, 0.3);">
+                        <div style="background: rgba(155, 89, 182, 0.08); padding: 12px; border-radius: 8px; margin: 10px 0; border: 1px solid rgba(155, 89, 182, 0.3); text-align: left;">
                             <div style="color: #8e44ad; font-size: 0.8rem; font-weight: 600; margin-bottom: 8px;">◤ 出演 ◢</div>
-                            <div style="color: #2c3e50; font-size: 0.8rem; font-weight: 500; line-height: 1.8; text-align: center;">
-                                <span style="white-space: nowrap;">Blue Lilac</span> / 
-                                <span style="white-space: nowrap;">マゼランソーシャルバケーション</span> / 
-                                <span style="color: #e74c3c; font-weight: 700; white-space: nowrap;">DELICIOUS×SPY</span>（17:50〜） / 
-                                <span style="white-space: nowrap;">wistaria</span> / 
-                                <span style="white-space: nowrap;">ふれふら</span> / 
+                            <div style="color: #2c3e50; font-size: 0.8rem; font-weight: 500; line-height: 1.85; text-align: left;">
+                                <div style="color: #e74c3c; font-weight: 700;"><span style="white-space: nowrap;">DELICIOUS×SPY</span>（17:50〜）</div>
+                                <span style="white-space: nowrap;">Blue Lilac</span><br>
+                                <span style="white-space: nowrap;">マゼランソーシャルバケーション</span><br>
+                                <span style="white-space: nowrap;">wistaria</span><br>
+                                <span style="white-space: nowrap;">ふれふら</span><br>
                                 <span style="white-space: nowrap;">NONAME</span>
                             </div>
                         </div>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 変更内容

4月5日「navey floor AKASAKA大作戦」の出演者セクションの表示を改善しました。

### 変更箇所
- `delicious_spy/band_live_complete_single_bright.html`
  - 出演者一覧を「/」区切りの横並びから、6/14 ReGと同じ縦並びリスト形式に変更
  - DELICIOUS×SPY（17:50〜）を赤字太字で先頭に配置
  - 他の出演者を1行ずつ縦に表示
  - text-alignをleftに統一
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3dbd737f-4203-4b54-b448-1ad075e59648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3dbd737f-4203-4b54-b448-1ad075e59648"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

